### PR TITLE
fix warn: warn - The class `duration-[1.5s]` is ambiguous and matches…

### DIFF
--- a/src/components/RoundImageButton.tsx
+++ b/src/components/RoundImageButton.tsx
@@ -39,7 +39,7 @@ export const RoundImageButton: React.FC<Props> = ({
             {alt && (
                 <span className="absolute inset-0 flex items-center justify-center
                                 text-white text-xl font-semibold bg-black/40
-                                opacity-0 group-hover:opacity-100 transition-opacity duration-[1.5s]">
+                                opacity-0 group-hover:opacity-100 transition-opacity duration-[1500ms]">
                     {alt}
                 </span>
             )}


### PR DESCRIPTION
… multiple utilities.

          warn - If this is content and not a class, replace it with `duration-&lsqb;1.5s&rsqb;` to silence this warning.